### PR TITLE
Instead of listing special characters in re, '?' is excluded

### DIFF
--- a/remi/server.py
+++ b/remi/server.py
@@ -344,7 +344,7 @@ class App(BaseHTTPRequestHandler, object):
         - file requests
     """
 
-    re_static_file = re.compile(r"^/res/([-_. \w\d]+)\?{0,1}(?:[\w\d]*)")  # https://regex101.com/r/uK1sX1/1
+    re_static_file = re.compile(r"^/res/([^\?]+)\?{0,1}(?:[\w\d]*)")
     re_attr_call = re.compile(r"^/*(\w+)\/(\w+)\?{0,1}(\w*\={1}(\w|\.)+\&{0,1})*$")
 
     def __init__(self, request, client_address, server, **app_args):


### PR DESCRIPTION
The re_static_file should identify static files in URLS. To my understanding the main goal is to seperate the filename from the query string (seperated by '?'). The current solution lists a couple of special characters that might occur in filenames, but is not complete by far.

Instead of listing all possible special characters that might occur in filenames (especially user generated ones), this version of re_static_file only excludes the question mark, which would sperate the filename from the query string.