### PR TITLE
remove dependency for pkg_resources

### DIFF
--- a/remi/__init__.py
+++ b/remi/__init__.py
@@ -60,4 +60,4 @@ elif useForVersionCheck == "pkg_resources":
         pass
 else:
     # neither importlib.metadata nor pkg_resources is available
-    pass
+    print("WARNING: cannot check remi version, please install importlib-metadata (python >= 3.8) or the pkg_resources module by installing setuptools")

--- a/remi/__init__.py
+++ b/remi/__init__.py
@@ -31,10 +31,33 @@ from .gui import (
 )
 
 from .server import App, Server, start
-from pkg_resources import get_distribution, DistributionNotFound
 
+# importlib.metadata is available in Python 3.8+
+useForVersionCheck = None
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # package is not installed
+    import importlib.metadata
+    useForVersionCheck = "importlib.metadata"
+except ImportError:
+    try:
+        import pkg_resources
+        useForVersionCheck = "pkg_resources"
+    except ImportError:
+        pass
+
+if useForVersionCheck == "importlib.metadata":
+    from importlib.metadata import version, PackageNotFoundError
+    try:
+        __version__ = version(__name__)
+    except PackageNotFoundError:
+        # package is not installed
+        pass
+elif useForVersionCheck == "pkg_resources":
+    from pkg_resources import get_distribution, DistributionNotFound
+    try:
+        __version__ = get_distribution(__name__).version
+    except DistributionNotFound:
+        # package is not installed
+        pass
+else:
+    # neither importlib.metadata nor pkg_resources is available
     pass

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ try:
 except:
     del params['setup_requires']
     params['use_scm_version'] = False
-    params['version'] = '2022.7.27'
+    params['version'] = '2026.02.04'
     setup(**params)

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ params = {
     'packages':setuptools.find_packages(),
     'include_package_data':True,
     'setup_requires':['setuptools_scm'],
+    'version': '2026.02.04',
 }
 try:
     setup(**params)
 except:
     del params['setup_requires']
     params['use_scm_version'] = False
-    params['version'] = '2026.02.04'
     setup(**params)


### PR DESCRIPTION
The `pkg_resources` module is being deprecated and was removed:

https://setuptools.pypa.io/en/latest/pkg_resources.html

It is to be replaced by `importlib.metadata`. This is what this MR addresses. For backward compatibility, it checks if `importlib.metadata` is available and refers back to `pkg_resources` if it is not. If neither is found, a warning is printed.

It would be good if this could be merged and a new package for distribution could be made.